### PR TITLE
Empty fields

### DIFF
--- a/pyclean.py
+++ b/pyclean.py
@@ -404,8 +404,8 @@ class Binary:
         if int(art[__LINES__]) < config.getint('binary', 'lines_allowed'):
             return False
         # Also avoid these costly checks where a References header is present.
-        skip_refs = ('References' in art and
-                     str(art['References']).startswith('<') and
+        skip_refs = (art[References] is not None and
+                     str(art[References]).startswith('<') and
                      config.getboolean('binary', 'fasttrack_references') and
                      int(art[__LINES__]) > 500)
         if skip_refs:
@@ -560,9 +560,9 @@ class Filter:
             self.midnight_events()
 
         # Attempt to split the From address into component parts
-        if 'From' in art:
+        if art[From] is not None:
             post['from_name'], \
-                post['from_email'] = self.addressParse(art['From'])
+                post['from_email'] = self.addressParse(art[From])
 
         if art[Content_Type] is not None:
             ct = self.regex_ct.match(art[Content_Type])
@@ -655,7 +655,7 @@ class Filter:
         # --- Everything below is accept / reject code ---
 
         # Reject any messages that don't have a Message-ID
-        if Message_ID not in art:
+        if art[Message_ID] is None:
             logging.warn("Wot no Message-ID!  Rejecting message because the "
                          "implications of accepting it are unpredictable.")
             return self.reject(art, post, "No Message-ID header")
@@ -948,9 +948,9 @@ class Filter:
                     do_lphn = True
                     if self.groups['phn_exclude_bool']:
                             do_lphn = False
-                    if (not do_lphn and art['References'] is None and
-                            'Subject' in art and
-                            str(art['Subject']).startswith("Re:")):
+                    if (not do_lphn and art[References] is None and
+                            art[Subject] is not None and
+                            str(art[Subject]).startswith("Re:")):
                         logging.info("emp_lphn: Exclude overridden - "
                                      "Subject Re but no Reference")
                         do_lphn = True

--- a/pyclean.py
+++ b/pyclean.py
@@ -1037,13 +1037,13 @@ class Filter:
         for hdr in art.keys():
             if hdr == '__BODY__' or hdr == '__LINES__' or art[hdr] is None:
                 continue
-            f.write('%s: %s\n' % (hdr, art[hdr]))
+            f.write('%s: %s\n' % (hdr, str(art[hdr]).replace('\r', '')))
         for hdr in post.keys():
             f.write('%s: %s\n' % (hdr, post[hdr]))
         f.write('\n')
         if (not trim or
                 art[__LINES__] <= config.get('logging', 'logart_maxlines')):
-            f.write(art[__BODY__])
+            f.write(str(art[__BODY__]).replace('\r', ''))
         else:
             maxlines = config.get('logging', 'logart_maxlines')
             loglines = 0
@@ -1051,6 +1051,7 @@ class Filter:
                 # Ignore quoted lines
                 if line.startswith(">"):
                     continue
+                line = line.replace('\r', '')
                 f.write(line + "\n")
                 loglines += 1
                 if loglines >= maxlines:


### PR DESCRIPTION
This PR is to apply after #6.
Fix the detection of empty header fields as the `art` dictionary contains all the usual header fields (more than 70, populated by **innd**).  When empty, they have a `None` value.

In some places in the code, the detection was wrong (looking at the presence of the header field name in the dictionary instead of the presence of a value).